### PR TITLE
Check support for django 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ matrix:
         env: TOX_ENV=py27-django17
       - python: 2.7
         env: TOX_ENV=py27-django18
+      - python: 2.7
+        env: TOX_ENV=py27-django111
       - python: 3.3
         env: TOX_ENV=py33-django15
       - python: 3.3
@@ -35,12 +37,16 @@ matrix:
         env: TOX_ENV=py34-django19
       - python: 3.4
         env: TOX_ENV=py34-django110
+      - python: 3.4
+        env: TOX_ENV=py34-django111
       - python: 3.5
         env: TOX_ENV=py35-django18
       - python: 3.5
         env: TOX_ENV=py35-django19
       - python: 3.5
         env: TOX_ENV=py35-django110
+      - python: 3.5
+        env: TOX_ENV=py35-django111
 
 
 script: tox -e $TOX_ENV

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,12 @@ matrix:
         env: TOX_ENV=py27-django17
       - python: 2.7
         env: TOX_ENV=py27-django18
+      - python: 2.7
+        env: TOX_ENV=py27-django19
+      - python: 2.7
+        env: TOX_ENV=py27-django110
+      - python: 2.7
+        env: TOX_ENV=py27-django111
       - python: 3.3
         env: TOX_ENV=py33-django15
       - python: 3.3
@@ -35,13 +41,16 @@ matrix:
         env: TOX_ENV=py34-django19
       - python: 3.4
         env: TOX_ENV=py34-django110
+      - python: 3.4
+        env: TOX_ENV=py34-django111
       - python: 3.5
         env: TOX_ENV=py35-django18
       - python: 3.5
         env: TOX_ENV=py35-django19
       - python: 3.5
         env: TOX_ENV=py35-django110
-
+      - python: 3.5
+        env: TOX_ENV=py35-django111
 
 script: tox -e $TOX_ENV
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -30,6 +30,7 @@ Direct Contributors
 * Gregory Shikhman
 * Mike Bryant
 * Fabio C. Barrionuevo da Luz
+* Sam Spencer
 
 Other Contributors
 ==================

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Mixins for Django's class-based views.
 
 [![Latest Travis CI status](https://travis-ci.org/brack3t/django-braces.svg)](https://travis-ci.org/brack3t/django-braces)
-[![PyPI version](https://badge.fury.io/py/django-braces.png)](http://badge.fury.io/py/django-braces)
+[![PyPI version](https://badge.fury.io/py/django-braces.svg)](http://badge.fury.io/py/django-braces)
 
 ## Documentation
 [Read The Docs](https://django-braces.readthedocs.io/en/latest/index.html)

--- a/braces/__init__.py
+++ b/braces/__init__.py
@@ -9,7 +9,7 @@ Several mixins for making Django's generic class-based views more useful.
 """
 
 __title__ = 'braces'
-__version__ = '1.11.0'
+__version__ = '1.12.0'
 __author__ = 'Kenneth Love and Chris Jones'
 __license__ = 'BSD 3-clause'
 __copyright__ = 'Copyright 2013 Kenneth Love and Chris Jones'

--- a/braces/views/_access.py
+++ b/braces/views/_access.py
@@ -164,6 +164,7 @@ class PermissionRequiredMixin(AccessMixin):
             ...
     """
     permission_required = None  # Default required perms to none
+    object_level_permissions = False
 
     def get_permission_required(self, request=None):
         """
@@ -185,7 +186,16 @@ class PermissionRequiredMixin(AccessMixin):
         Returns whether or not the user has permissions
         """
         perms = self.get_permission_required(request)
-        return request.user.has_perm(perms)
+        has_permission = False
+
+        if self.object_level_permissions: 
+            if hasattr(self, 'object')  and self.object is not None: 
+                has_permission = request.user.has_perm(self.get_permission_required(request), self.object)
+            elif hasattr(self, 'get_object') and callable(self.get_object):
+                has_permission = request.user.has_perm(self.get_permission_required(request), self.get_object())
+        else:
+            has_permission = request.user.has_perm(self.get_permission_required(request))
+        return has_permission
 
     def dispatch(self, request, *args, **kwargs):
         """

--- a/braces/views/_ajax.py
+++ b/braces/views/_ajax.py
@@ -133,7 +133,8 @@ class JsonRequestResponseMixin(JSONResponseMixin):
         self.kwargs = kwargs
 
         self.request_json = self.get_request_json()
-        if self.require_json and self.request_json is None:
+        if request.method != 'OPTIONS'\
+                and self.require_json and self.request_json is None:
             return self.render_bad_request_response()
         return super(JsonRequestResponseMixin, self).dispatch(
             request, *args, **kwargs)

--- a/braces/views/_ajax.py
+++ b/braces/views/_ajax.py
@@ -133,8 +133,11 @@ class JsonRequestResponseMixin(JSONResponseMixin):
         self.kwargs = kwargs
 
         self.request_json = self.get_request_json()
-        if request.method != 'OPTIONS'\
-                and self.require_json and self.request_json is None:
+        if all([
+            request.method != 'OPTIONS',
+            self.require_json,
+            self.request_json is None
+        ]):
             return self.render_bad_request_response()
         return super(JsonRequestResponseMixin, self).dispatch(
             request, *args, **kwargs)

--- a/braces/views/_queries.py
+++ b/braces/views/_queries.py
@@ -11,8 +11,8 @@ class SelectRelatedMixin(object):
     select_related = None  # Default related fields to none
 
     def get_queryset(self):
-        if self.select_related is None:  # If no fields were provided,
-                                         # raise a configuration error
+        if self.select_related is None:
+            # If no fields were provided, raise a configuration error
             raise ImproperlyConfigured(
                 '{0} is missing the select_related property. This must be '
                 'a tuple or list.'.format(self.__class__.__name__))
@@ -42,8 +42,8 @@ class PrefetchRelatedMixin(object):
     prefetch_related = None  # Default prefetch fields to none
 
     def get_queryset(self):
-        if self.prefetch_related is None:  # If no fields were provided,
-                                           # raise a configuration error
+        if self.prefetch_related is None:
+            # If no fields were provided, raise a configuration error
             raise ImproperlyConfigured(
                 '{0} is missing the prefetch_related property. This must be '
                 'a tuple or list.'.format(self.__class__.__name__))

--- a/docs/access.rst
+++ b/docs/access.rst
@@ -67,7 +67,9 @@ PermissionRequiredMixin
 
 This mixin was originally written by `Daniel Sokolowski`_ (`code here`_), but this version eliminates an unneeded render if the permissions check fails.
 
-Rather than overloading the dispatch method manually on every view that needs to check for the existence of a permission, use this mixin and set the ``permission_required`` class attribute on your view. If you don't specify ``permission_required`` on your view, an ``ImproperlyConfigured`` exception is raised reminding you that you haven't set it.
+Rather than overloading the dispatch method manually on every view that needs to check for the existence of a permission, use this mixin and set the ``permission_required`` class attribute on your view.
+If you don't specify ``permission_required`` on your view, an ``ImproperlyConfigured`` exception is raised reminding you that you haven't set it.
+If you need to enforce permissions against a given object, set the ``object_level_permissions`` attribute to ``True``.
 
 The one limitation of this mixin is that it can **only** accept a single permission. If you need multiple permissions use :ref:`MultiplePermissionsRequiredMixin`.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-factory_boy==2.9.0
+factory_boy
 mock
 pytest-django
 pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-factory_boy<2.9
+factory_boy==2.9.0
 mock
 pytest-django
 pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-factory_boy
+factory_boy<2.9
 mock
 pytest-django
 pytest-cov

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -40,21 +40,11 @@ class UserFactory(factory.django.DjangoModelFactory):
     first_name = factory.Sequence(lambda n: 'John {0}'.format(n))
     last_name = factory.Sequence(lambda n: 'Doe {0}'.format(n))
     email = factory.Sequence(lambda n: 'user{0}@example.com'.format(n))
-    password = 'asdf1234'
+    password = factory.PostGenerationMethodCall('set_password', 'asdf1234')
 
     class Meta:
         model = User
         abstract = False
-
-    @classmethod
-    def _prepare(cls, create, **kwargs):
-        password = kwargs.pop('password', None)
-        user = super(UserFactory, cls)._prepare(create, **kwargs)
-        if password:
-            user.set_password(password)
-            if create:
-                user.save()
-        return user
 
     @factory.post_generation
     def permissions(self, create, extracted, **kwargs):

--- a/tests/test_access_mixins.py
+++ b/tests/test_access_mixins.py
@@ -9,6 +9,8 @@ from django import VERSION as DJANGO_VERSION
 from django.test.utils import override_settings
 from django.core.exceptions import ImproperlyConfigured, PermissionDenied
 from django.http import Http404, HttpResponse
+from django.utils.timezone import make_aware, get_current_timezone
+
 try:
     from django.urls import reverse_lazy
 except ImportError:
@@ -706,6 +708,7 @@ class TestRecentLoginRequiredMixin(test.TestCase):
     def test_recent_login(self):
         self.view_class.max_last_login_delta = 1800
         last_login = datetime.datetime.now()
+        last_login = make_aware(last_login, get_current_timezone())
         user = UserFactory(last_login=last_login)
         self.client.login(username=user.username, password='asdf1234')
         resp = self.client.get(self.recent_view_url)
@@ -715,6 +718,7 @@ class TestRecentLoginRequiredMixin(test.TestCase):
     def test_outdated_login(self):
         self.view_class.max_last_login_delta = 0
         last_login = datetime.datetime.now() - datetime.timedelta(hours=2)
+        last_login = make_aware(last_login, get_current_timezone())
         user = UserFactory(last_login=last_login)
         self.client.login(username=user.username, password='asdf1234')
         resp = self.client.get(self.outdated_view_url)
@@ -722,6 +726,7 @@ class TestRecentLoginRequiredMixin(test.TestCase):
 
     def test_not_logged_in(self):
         last_login = datetime.datetime.now()
+        last_login = make_aware(last_login, get_current_timezone())
         user = UserFactory(last_login=last_login)
         resp = self.client.get(self.recent_view_url)
         assert resp.status_code != 200

--- a/tests/test_other_mixins.py
+++ b/tests/test_other_mixins.py
@@ -786,6 +786,6 @@ class TestHeaderMixin(test.TestCase):
         self.assertEqual(response['X-DJANGO-BRACES-1'], '1')
         self.assertEqual(response['X-DJANGO-BRACES-2'], '2')
 
-    def test_method(self):
+    def test_existing(self):
         response = self.client.get('/headers/existing/')
         self.assertEqual(response['X-DJANGO-BRACES-EXISTING'], 'value')

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ commands =
 
 deps =
     mock
-    factory_boy<2.9
+    factory_boy
     py{27,33,34}: pytest-django==2.9.1
     py{35,36}: pytest-django>2.9.1
     py{27,33,34,35,36}: coverage==4.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,33,34}-django{15,16,17,18},py{34,35,36}-django{18,19,110}
+envlist = py{27,33,34}-django{15,16,17,18,19,110,111},py{34,35,36}
 install_command = pip install {opts} {packages}
 
 [testenv]
@@ -15,7 +15,7 @@ commands =
 
 deps =
     mock
-    factory_boy
+    factory_boy==2.8.1
     py{27,33,34}: pytest-django==2.9.1
     py{35,36}: pytest-django>2.9.1
     py{27,33,34,35,36}: coverage==4.1
@@ -26,3 +26,4 @@ deps =
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
+    django111: Django>=1.11,<1.12

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,33,34}-django{15,16,17,18},py{34,35,36}-django{18,19,110}
+envlist = py{27}-django{15,16,17,18,19,110,111},py{33,34}-django{15,16,17,18},py{34,35,36}-django{18,19,110,111}
 install_command = pip install {opts} {packages}
 
 [testenv]
@@ -15,7 +15,7 @@ commands =
 
 deps =
     mock
-    factory_boy
+    factory_boy<2.9
     py{27,33,34}: pytest-django==2.9.1
     py{35,36}: pytest-django>2.9.1
     py{27,33,34,35,36}: coverage==4.1
@@ -26,3 +26,4 @@ deps =
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
+    django111: Django>=1.11,<2.0

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ commands =
 deps =
     mock
     factory_boy<2.9
-    django{15,16}: pytest-django==2.9.1
+    py{27,33,34}: pytest-django==2.9.1
     py{35,36}: pytest-django>2.9.1
     py{27,33,34,35,36}: coverage==4.1
     argparse

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ commands =
 deps =
     mock
     factory_boy<2.9
-    py{27,33,34}: pytest-django==2.9.1
+    django{15,16}: pytest-django==2.9.1
     py{35,36}: pytest-django>2.9.1
     py{27,33,34,35,36}: coverage==4.1
     argparse


### PR DESCRIPTION
Fix an issue with factoryboy>=2.9 (remove UserFactory._prepare() hack).
Add django1.11 in both travis and tox configs.
Fix some naive datetime warning in tests.